### PR TITLE
fix: 修复MySQL连接失败导致程序panic的问题

### DIFF
--- a/pkg/di/gorm.go
+++ b/pkg/di/gorm.go
@@ -26,27 +26,114 @@
 package di
 
 import (
+	"fmt"
+	"log"
+	"time"
+
 	"github.com/spf13/viper"
 	"gorm.io/driver/mysql"
 	"gorm.io/gorm"
 	"gorm.io/gorm/logger"
 )
 
-// InitDB 初始化数据库
+// InitDB 初始化数据库（带重试机制）
 func InitDB() *gorm.DB {
 	addr := viper.GetString("mysql.addr")
-	db, err := gorm.Open(mysql.Open(addr), &gorm.Config{
-		Logger: logger.Default.LogMode(logger.Info),
-	})
 
-	if err != nil {
-		panic(err)
+	// 数据库连接重试配置
+	maxRetries := 5
+	retryDelay := time.Second * 2
+
+	var db *gorm.DB
+	var err error
+
+	log.Printf("正在连接数据库: %s", addr)
+
+	// 重试连接数据库
+	for i := 0; i < maxRetries; i++ {
+		db, err = gorm.Open(mysql.Open(addr), &gorm.Config{
+			Logger: logger.Default.LogMode(logger.Info),
+		})
+
+		if err == nil {
+			log.Printf("数据库连接成功")
+			break
+		}
+
+		log.Printf("数据库连接失败 (尝试 %d/%d): %v", i+1, maxRetries, err)
+
+		if i < maxRetries-1 {
+			log.Printf("等待 %v 后重试...", retryDelay)
+			time.Sleep(retryDelay)
+			// 增加重试延迟（指数退避）
+			retryDelay *= 2
+		}
 	}
+
+	// 如果所有重试都失败，记录错误但不panic
+	if err != nil {
+		log.Printf("数据库连接失败，已尝试 %d 次。错误: %v", maxRetries, err)
+		log.Printf("程序将以降级模式运行，某些功能可能不可用")
+		// 返回一个nil的数据库连接，让调用方处理
+		return nil
+	}
+
+	// 测试数据库连接
+	sqlDB, err := db.DB()
+	if err != nil {
+		log.Printf("获取sql.DB失败: %v", err)
+		return nil
+	}
+
+	if err := sqlDB.Ping(); err != nil {
+		log.Printf("数据库ping失败: %v", err)
+		return nil
+	}
+
+	// 设置连接池参数
+	sqlDB.SetMaxIdleConns(10)
+	sqlDB.SetMaxOpenConns(100)
+	sqlDB.SetConnMaxLifetime(time.Hour)
 
 	// 初始化表
 	if err = InitTables(db); err != nil {
-		panic(err)
+		log.Printf("初始化数据库表失败: %v", err)
+		// 不panic，让程序继续运行
+		return db
 	}
 
+	log.Printf("数据库初始化完成")
 	return db
+}
+
+// InitDBWithFallback 带降级处理的数据库初始化
+func InitDBWithFallback() (*gorm.DB, error) {
+	db := InitDB()
+	if db == nil {
+		return nil, fmt.Errorf("数据库连接失败")
+	}
+	return db, nil
+}
+
+// CheckDBHealth 检查数据库健康状态
+func CheckDBHealth(db *gorm.DB) error {
+	if db == nil {
+		return fmt.Errorf("数据库连接为空")
+	}
+
+	sqlDB, err := db.DB()
+	if err != nil {
+		return fmt.Errorf("获取数据库连接失败: %v", err)
+	}
+
+	if err := sqlDB.Ping(); err != nil {
+		return fmt.Errorf("数据库ping失败: %v", err)
+	}
+
+	return nil
+}
+
+// IsDBAvailable 检查数据库是否可用
+func IsDBAvailable(db *gorm.DB) bool {
+	return CheckDBHealth(db) == nil
 }


### PR DESCRIPTION
- 添加数据库连接重试机制，支持指数退避
- 在数据库连接失败时优雅降级，不再panic
- 新增数据库健康检查功能
- 添加/health端点用于监控数据库状态
- 完善Mock模式下的错误处理
- 确保程序在数据库不可用时仍能正常启动并提供基础服务

修复内容：
1. InitDB函数增加5次重试机制和连接池配置
2. 新增CheckDBHealth和IsDBAvailable函数
3. 主程序增加数据库状态检查和降级处理
4. 定时任务和异步任务仅在数据库可用时启动
5. 增加健康检查端点便于监控