### PR TITLE
fix::issue#302 修改用户头像数据类型

### DIFF
--- a/deploy/mysql/init.sql
+++ b/deploy/mysql/init.sql
@@ -1,15 +1,15 @@
 -- 创建数据库
-CREATE DATABASE IF NOT EXISTS CloudOps DEFAULT CHARACTER SET utf8mb4 COLLATE utf8mb4_general_ci;
+CREATE DATABASE IF NOT EXISTS cloudops DEFAULT CHARACTER SET utf8mb4 COLLATE utf8mb4_general_ci;
 
 -- 使用数据库
-USE cloudOps;
+USE cloudops;
 
 -- 设置时区
 SET time_zone = '+08:00';
 
 -- 创建用户（如果需要）
 -- CREATE USER IF NOT EXISTS 'cloudops'@'%' IDENTIFIED BY 'cloudops123';
--- GRANT ALL PRIVILEGES ON cloudOps.* TO 'cloudops'@'%';
+-- GRANT ALL PRIVILEGES ON cloudops.* TO 'cloudops'@'%';
 -- FLUSH PRIVILEGES;
 
 -- 基础表结构会由应用程序自动创建

--- a/internal/model/user.go
+++ b/internal/model/user.go
@@ -33,7 +33,7 @@ type User struct {
 	RealName     string `json:"real_name" gorm:"type:varchar(100);comment:用户真实姓名"`                                    // 用户真实姓名
 	Domain       string `json:"domain" gorm:"type:varchar(100);default:'default';comment:用户域"`                        // 用户域，默认default
 	Desc         string `json:"desc" gorm:"type:text;comment:用户描述"`                                                   // 用户描述，支持较长文本
-	Avatar       string `json:"avatar" gorm:"type:varchar(255);comment:用户头像"`                                         // 用户头像
+	Avatar       string `json:"avatar" gorm:"type:longblob;comment:用户头像"`                                         // 用户头像
 	Mobile       string `json:"mobile" gorm:"type:varchar(20);comment:手机号"`                                           // 手机号，添加唯一索引
 	Email        string `json:"email" gorm:"type:varchar(100);comment:邮箱"`                                            // 邮箱，添加唯一索引
 	FeiShuUserId string `json:"fei_shu_user_id" gorm:"type:varchar(50);comment:飞书用户ID"`                               // 飞书用户ID，添加唯一索引


### PR DESCRIPTION
1. refactor(model): 将用户头像字段类型从varchar改为longblob
    修改用户头像字段类型以支持存储二进制数据，提升头像存储的灵活性
2. fix(deploy): 统一数据库名称大小写为小写
    将数据库名称从大小写混合的 CloudOps 统一改为全小写的 cloudops，保持命名一致性，与配置文件一致
关联的issue#302 https://github.com/GoSimplicity/AI-CloudOps/issues/302